### PR TITLE
allow errors to expire immediately with -1 or 0

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -312,8 +312,8 @@ func TestExpires(t *testing.T) {
 	}
 
 	// Errors are deleted immediately.
-	{
-		c := New[string, string](MaxErrorAge(1))
+	for _, d := range []time.Duration{-1, 0, 1} {
+		c := New[string, string](MaxErrorAge(d))
 		v, err, s := c.Get("foo", func() (string, error) { return "", errors.New("foo") })
 		vcheck(t, got[string]{v, err, s}, got[string]{"", errors.New("foo"), Miss})
 		v, err, s = c.Get("foo", func() (string, error) { return "bar", nil })


### PR DESCRIPTION
This brings the MaxErrAge behavior in line with MaxAge behavior.

Previously, if you wanted an error to expire immediately, you needed to use a positive value for MaxErrAge. You could not use 0, because 0 would opt into storing the value forever. You also could not use a negative number, because negative ttl's were internally ignored. If you wanted the error to not be cached, you had to use a tiny err expiry (i.e., 1).

Now, you can use negative or 0 for MaxErrAge to disable caching, same as how MaxAge works.