### PR TITLE
cache: add Clear, fix NewItem/NewSet, fix typos, add MaxIdleAge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following logical mapping can be done from `sync.Map` to `cache.Cache`
 functions:
 
 ```go
+  sync.Map.Clear            == cache.Cache.Clear
   sync.Map.CompareAndDelete == cache.Cache.CompareAndDelete
   sync.Map.CompareAndSwap   == cache.Cache.CompareAndSwap
   sync.Map.Delete           == (no equivalent -- we just provide LoadAndDelete)

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -88,6 +88,7 @@ type (
 		maxAge            time.Duration
 		maxStaleAge       time.Duration
 		maxErrAge         time.Duration
+		maxIdleAge        time.Duration
 		ageSet            bool
 		errAgeSet         bool
 		autoCleanInterval time.Duration
@@ -117,6 +118,9 @@ func (cfg *cfg) newExpires(err error) int64 {
 		del0 = cfg.maxErrAge <= 0
 	} else {
 		ttl = cfg.maxAge
+		if ttl == 0 && !cfg.ageSet && cfg.maxIdleAge > 0 {
+			ttl = cfg.maxIdleAge
+		}
 		del0 = cfg.ageSet && cfg.maxAge <= 0
 	}
 	if del0 {
@@ -158,6 +162,14 @@ func MaxStaleAge(age time.Duration) Opt { return opt{fn: func(c *cfg) { c.maxSta
 // entirely.
 func MaxErrorAge(age time.Duration) Opt {
 	return opt{fn: func(c *cfg) { c.maxErrAge, c.errAgeSet = age, true }}
+}
+
+// MaxIdleAge opts in to extending an entry's expiry on each successful
+// access. Each time Get or TryGet returns a Hit without an error, the
+// entry's expiry is reset to now + age. If MaxAge is not set, the idle
+// age is also used as the initial TTL.
+func MaxIdleAge(age time.Duration) Opt {
+	return opt{fn: func(c *cfg) { c.maxIdleAge = age }}
 }
 
 // AutoCleanInterval begins a goroutine that calls Clean every interval. The
@@ -208,7 +220,7 @@ func New[K comparable, V any](opts ...Opt) *Cache[K, V] {
 func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeyState) {
 	r := c.read()
 	e := r.m[k]
-	if v, err, s = e.get(); s == Hit {
+	if v, err, s = e.get(c.cfg.maxIdleAge); s == Hit {
 		return v, err, s
 	}
 
@@ -217,7 +229,7 @@ func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeySta
 	c.mu.Lock()
 	r = c.read()
 	e = r.m[k]
-	if v, err, s = e.get(); s == Hit {
+	if v, err, s = e.get(c.cfg.maxIdleAge); s == Hit {
 		c.mu.Unlock()
 		return v, err, s
 	}
@@ -229,7 +241,7 @@ func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeySta
 		e = c.dirty[k]
 		c.missed(r)
 		r = c.read()
-		if v, err, s = e.get(); s == Hit {
+		if v, err, s = e.get(c.cfg.maxIdleAge); s == Hit {
 			c.mu.Unlock()
 			return v, err, s
 		}
@@ -263,7 +275,7 @@ func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeySta
 	// stale to be returned now, `get` returns it. If `get` returns a Hit,
 	// we ended up waiting for ourself and we return a miss. There should
 	// be no Miss returns from `get`.
-	v, err, s = e.get()
+	v, err, s = e.get(c.cfg.maxIdleAge)
 	switch s {
 	case Miss, Hit:
 		// We always return l.v and l.err. If this expires immediately,
@@ -299,7 +311,7 @@ func (c *Cache[K, V]) tryLoadEnt(k K, dirty func()) *ent[V] {
 // cached is expired, this returns Miss.
 func (c *Cache[K, V]) TryGet(k K) (V, error, KeyState) {
 	e := c.tryLoadEnt(k, nil)
-	return e.tryGet(0)
+	return e.tryGet(0, c.cfg.maxIdleAge)
 }
 
 // Delete deletes the value for a key and returns the prior value, if stored
@@ -307,7 +319,7 @@ func (c *Cache[K, V]) TryGet(k K) (V, error, KeyState) {
 func (c *Cache[K, V]) Delete(k K) (V, error, KeyState) {
 	e := c.tryLoadEnt(k, func() { delete(c.dirty, k) })
 	defer e.del()
-	return e.tryGet(0)
+	return e.tryGet(0, 0)
 }
 
 // Expire sets a stored value to expire immediately, meaning the next Get will
@@ -326,7 +338,7 @@ func (c *Cache[K, V]) Range(fn func(K, V, error) bool) {
 	// current time when we enter range and avoid it in all tryGet calls.
 	now := now()
 	c.each(func(k K, e *ent[V]) bool {
-		v, err, s := e.tryGet(now)
+		v, err, s := e.tryGet(now, 0)
 		if s.IsMiss() {
 			return true
 		}
@@ -706,7 +718,7 @@ func newStale[V any](v V, expires int64, age time.Duration) *stale[V] {
 // get always returns the value or the stale value. We do not check if our
 // value is expired: we call this at the end of Get, we must always return
 // something even if it is to be immediately expired.
-func (e *ent[V]) get() (v V, err error, state KeyState) {
+func (e *ent[V]) get(extend time.Duration) (v V, err error, state KeyState) {
 	l := e.load()
 	var waited bool
 	if l == nil {
@@ -741,10 +753,13 @@ func (e *ent[V]) get() (v V, err error, state KeyState) {
 		}
 		return v, err, state
 	}
+	if extend > 0 && l.err == nil {
+		l.expires.Store(now + int64(extend))
+	}
 	return l.v, l.err, Hit
 }
 
-func (e *ent[V]) tryGet(n64 int64) (v V, err error, state KeyState) {
+func (e *ent[V]) tryGet(n64 int64, extend time.Duration) (v V, err error, state KeyState) {
 	if e == nil {
 		return v, err, state
 	}
@@ -778,6 +793,9 @@ func (e *ent[V]) tryGet(n64 int64) (v V, err error, state KeyState) {
 		if expired {
 			return v, err, state
 		}
+	}
+	if extend > 0 && l.err == nil {
+		l.expires.Store(now + int64(extend))
 	}
 	return l.v, l.err, Hit
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -209,7 +209,7 @@ func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeySta
 	r := c.read()
 	e := r.m[k]
 	if v, err, s = e.get(); s == Hit {
-		return
+		return v, err, s
 	}
 
 	// We missed in the read map. We lock and check again to guard against
@@ -219,7 +219,7 @@ func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeySta
 	e = r.m[k]
 	if v, err, s = e.get(); s == Hit {
 		c.mu.Unlock()
-		return
+		return v, err, s
 	}
 
 	// We could have an entry in our read map that was deleted and has not
@@ -231,7 +231,7 @@ func (c *Cache[K, V]) Get(k K, miss func() (V, error)) (v V, err error, s KeySta
 		r = c.read()
 		if v, err, s = e.get(); s == Hit {
 			c.mu.Unlock()
-			return
+			return v, err, s
 		}
 	}
 
@@ -376,6 +376,15 @@ func (c *Cache[K, V]) Clean() {
 	})
 }
 
+// Clear deletes all keys from the cache, resetting it to an empty state.
+func (c *Cache[K, V]) Clear() {
+	c.mu.Lock()
+	c.dirty = nil
+	c.storeRead(read[K, V]{})
+	c.misses = 0
+	c.mu.Unlock()
+}
+
 // StopAutoClean stops the auto clean goroutine that is began with the
 // AutoClean option.
 func (c *Cache[K, V]) StopAutoClean() {
@@ -438,7 +447,7 @@ func (c *Cache[K, V]) Swap(k K, v V) (old V, oldErr error, oldState KeyState) {
 			}
 			was = rm
 			if e.p.CompareAndSwap(rm, l) {
-				return
+				return old, oldErr, oldState
 			}
 		}
 	}
@@ -455,7 +464,7 @@ func (c *Cache[K, V]) Swap(k K, v V) (old V, oldErr error, oldState KeyState) {
 		c.storeDirty(r, k, e)
 	}
 	c.mu.Unlock()
-	return
+	return old, oldErr, oldState
 }
 
 func (l *loading[V]) setve(v V, err error, expires int64) {
@@ -501,7 +510,7 @@ func (c *Cache[K, V]) CompareAndSwap(k K, old, new V) bool {
 }
 
 // CompareAndDelete deletes the entry for k if the value has finished loading
-// the the value is equal to old. The type V must be comparable.
+// and the value is equal to old. The type V must be comparable.
 func (c *Cache[K, V]) CompareAndDelete(k K, old V) (deleted bool) {
 	r := c.read()
 	e, ok := r.m[k]
@@ -613,11 +622,14 @@ func (c *Cache[K, V]) finalizedLoading(v V) *loading[V] {
 	l := &loading[V]{
 		v: v,
 	}
-	l.expires.Store(c.cfg.newExpires(nil))
-	l.state.Store(stateFinalized)
-	if c.cfg.maxStaleAge != 0 {
-		l.stale = newStale(v, now(), c.cfg.maxStaleAge)
+	expires := c.cfg.newExpires(nil)
+	if expires != 0 || c.cfg.maxStaleAge != 0 {
+		l.expires.Store(expires)
+		if c.cfg.maxStaleAge != 0 {
+			l.stale = newStale(v, l.expires.Load(), c.cfg.maxStaleAge)
+		}
 	}
+	l.state.Store(stateFinalized)
 	return l
 }
 
@@ -700,7 +712,7 @@ func (e *ent[V]) get() (v V, err error, state KeyState) {
 	if l == nil {
 		// Could be nil if deleted while in the read map, or
 		// promotingDelete.
-		return
+		return v, err, state
 	}
 	if !l.finalized() {
 		if l.stale != nil && !l.stale.expired(now()) {
@@ -718,7 +730,7 @@ func (e *ent[V]) get() (v V, err error, state KeyState) {
 	// if the user is configured to never cache and they're just using
 	// request collapsing: we still want to return the now expired value.
 	now := now()
-	if !waited && l.expired(now) || l.err != nil {
+	if (!waited && l.expired(now)) || l.err != nil {
 		if l.stale != nil && !l.stale.expired(now) {
 			return l.stale.v, nil, Stale
 		}
@@ -727,18 +739,22 @@ func (e *ent[V]) get() (v V, err error, state KeyState) {
 		if !l.expired(now) {
 			return l.v, l.err, Hit
 		}
-		return
+		return v, err, state
 	}
 	return l.v, l.err, Hit
 }
 
 func (e *ent[V]) tryGet(n64 int64) (v V, err error, state KeyState) {
 	if e == nil {
-		return
+		return v, err, state
 	}
 	l := e.load()
 	if l == nil { // deleting or promotedDelete
-		return
+		return v, err, state
+	}
+	// Fast path: finalized, no expiry, no error — skip time checks.
+	if l.onlyFinalized() && l.expires.Load() == 0 && l.err == nil {
+		return l.v, nil, Hit
 	}
 	if n64 == 0 {
 		n64 = now()
@@ -751,7 +767,7 @@ func (e *ent[V]) tryGet(n64 int64) (v V, err error, state KeyState) {
 		if l.stale != nil && !l.stale.expired(now) {
 			return l.stale.v, nil, Stale
 		}
-		return
+		return v, err, state
 	}
 
 	// If we have an error or we are expired, we maybe return the stale.
@@ -760,7 +776,7 @@ func (e *ent[V]) tryGet(n64 int64) (v V, err error, state KeyState) {
 			return l.stale.v, nil, Stale
 		}
 		if expired {
-			return
+			return v, err, state
 		}
 	}
 	return l.v, l.err, Hit
@@ -842,10 +858,15 @@ func (i *Item[V]) CompareAndSwap(old, new V) (swapped bool) {
 	return i.c.CompareAndSwap(struct{}{}, old, new)
 }
 
-// CompareAndDelete deletes the item if the value has finished loading the the
+// CompareAndDelete deletes the item if the value has finished loading and the
 // value is equal to old. The type V must be comparable.
 func (i *Item[V]) CompareAndDelete(old V) (deleted bool) {
 	return i.c.CompareAndDelete(struct{}{}, old)
+}
+
+// Clear deletes the cached item, resetting the item to an empty state.
+func (i *Item[V]) Clear() {
+	i.c.Clear()
 }
 
 /////////
@@ -927,6 +948,11 @@ func (s *Set[K]) Clean() {
 // the load is canceled and Get returns nil.
 func (s *Set[K]) Set(k K) {
 	s.c.Set(k, struct{}{})
+}
+
+// Clear deletes all keys from the set, resetting it to an empty state.
+func (s *Set[K]) Clear() {
+	s.c.Clear()
 }
 
 // StopAutoClean stops the auto clean goroutine that is began with the

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -363,3 +363,77 @@ func TestExpires(t *testing.T) {
 		}
 	}
 }
+
+func TestMaxIdleAge(t *testing.T) {
+	// MaxIdleAge alone: entry stays alive while accessed within the window,
+	// expires after inactivity.
+	t.Run("alone", func(t *testing.T) {
+		c := New[string, string](MaxIdleAge(50 * time.Millisecond))
+		c.Get("foo", func() (string, error) { return "bar", nil })
+		time.Sleep(10 * time.Millisecond)
+
+		// Access within the idle window — should still be a hit and extend.
+		for i := 0; i < 5; i++ {
+			v, err, s := c.TryGet("foo")
+			vcheck(t, got[string]{v, err, s}, got[string]{"bar", nil, Hit})
+			time.Sleep(30 * time.Millisecond) // each access resets the 50ms idle
+		}
+
+		// Now stop accessing. After 50ms of inactivity, it should expire.
+		time.Sleep(60 * time.Millisecond)
+		v, err, s := c.TryGet("foo")
+		vcheck(t, got[string]{v, err, s}, got[string]{"", nil, Miss})
+	})
+
+	// MaxIdleAge + MaxAge: initial expiry uses MaxAge, subsequent accesses
+	// extend using MaxIdleAge.
+	t.Run("with_max_age", func(t *testing.T) {
+		c := New[string, string](MaxAge(50*time.Millisecond), MaxIdleAge(50*time.Millisecond))
+		c.Get("foo", func() (string, error) { return "bar", nil })
+
+		// Keep alive well past the original MaxAge.
+		for i := 0; i < 5; i++ {
+			time.Sleep(30 * time.Millisecond)
+			v, err, s := c.Get("foo", func() (string, error) { return "baz", nil })
+			vcheck(t, got[string]{v, err, s}, got[string]{"bar", nil, Hit})
+		}
+
+		// Stop accessing, should expire.
+		time.Sleep(60 * time.Millisecond)
+		v, err, s := c.TryGet("foo")
+		vcheck(t, got[string]{v, err, s}, got[string]{"", nil, Miss})
+	})
+
+	// MaxIdleAge doesn't extend errors.
+	t.Run("no_extend_errors", func(t *testing.T) {
+		c := New[string, string](MaxAge(50*time.Millisecond), MaxIdleAge(50*time.Millisecond))
+		c.Get("foo", func() (string, error) { return "", errors.New("err") })
+		time.Sleep(10 * time.Millisecond)
+
+		// Access the errored entry — it should not be extended.
+		v, err, s := c.TryGet("foo")
+		vcheck(t, got[string]{v, err, s}, got[string]{"", errors.New("err"), Hit})
+
+		// Wait past expiry — should be gone.
+		time.Sleep(50 * time.Millisecond)
+		v, err, s = c.TryGet("foo")
+		vcheck(t, got[string]{v, err, s}, got[string]{"", nil, Miss})
+	})
+
+	// Range doesn't extend.
+	t.Run("range_no_extend", func(t *testing.T) {
+		c := New[string, string](MaxAge(50*time.Millisecond), MaxIdleAge(50*time.Millisecond))
+		c.Get("foo", func() (string, error) { return "bar", nil })
+
+		// Range over entries repeatedly — should NOT extend expiry.
+		for i := 0; i < 3; i++ {
+			time.Sleep(20 * time.Millisecond)
+			c.Range(func(string, string, error) bool { return true })
+		}
+
+		// Should be expired by now (>50ms since creation, range didn't extend).
+		time.Sleep(20 * time.Millisecond)
+		v, err, s := c.TryGet("foo")
+		vcheck(t, got[string]{v, err, s}, got[string]{"", nil, Miss})
+	})
+}

--- a/cache/map_reference_test.go
+++ b/cache/map_reference_test.go
@@ -20,6 +20,7 @@ type mapInterface[K comparable] interface {
 	Swap(key K, value any) (previous any, loaded bool)
 	CompareAndSwap(key K, old, new any) (swapped bool)
 	CompareAndDelete(key K, old any) (deleted bool)
+	Clear()
 	Range(func(key K, value any) (shouldContinue bool))
 }
 
@@ -33,7 +34,7 @@ func (m *RWMutexMap[K]) Load(key K) (value any, ok bool) {
 	m.mu.RLock()
 	value, ok = m.dirty[key]
 	m.mu.RUnlock()
-	return
+	return value, ok
 }
 
 func (m *RWMutexMap[K]) Store(key K, value any) {
@@ -68,7 +69,7 @@ func (m *RWMutexMap[K]) Swap(key K, value any) (previous any, loaded bool) {
 	previous, loaded = m.dirty[key]
 	m.dirty[key] = value
 	m.mu.Unlock()
-	return
+	return previous, loaded
 }
 
 func (m *RWMutexMap[K]) LoadAndDelete(key K) (value any, loaded bool) {
@@ -86,6 +87,12 @@ func (m *RWMutexMap[K]) LoadAndDelete(key K) (value any, loaded bool) {
 func (m *RWMutexMap[K]) Delete(key K) {
 	m.mu.Lock()
 	delete(m.dirty, key)
+	m.mu.Unlock()
+}
+
+func (m *RWMutexMap[K]) Clear() {
+	m.mu.Lock()
+	m.dirty = nil
 	m.mu.Unlock()
 }
 
@@ -175,6 +182,10 @@ func (c *CacheMap[K]) CompareAndSwap(key K, old, new any) (swapped bool) {
 
 func (c *CacheMap[K]) CompareAndDelete(key K, old any) (deleted bool) {
 	return c.c.CompareAndDelete(key, old)
+}
+
+func (c *CacheMap[K]) Clear() {
+	c.c.Clear()
 }
 
 func (c *CacheMap[K]) Delete(key K) {

--- a/cache/map_test.go
+++ b/cache/map_test.go
@@ -25,6 +25,7 @@ const (
 	opSwap             = mapOp("Swap")
 	opCompareAndSwap   = mapOp("CompareAndSwap")
 	opCompareAndDelete = mapOp("CompareAndDelete")
+	opClear            = mapOp("Clear")
 )
 
 var mapOps = [...]mapOp{
@@ -36,6 +37,7 @@ var mapOps = [...]mapOp{
 	opSwap,
 	opCompareAndSwap,
 	opCompareAndDelete,
+	opClear,
 }
 
 // mapCall is a quick.Generator for calls on mapInterface.
@@ -73,6 +75,9 @@ func (c mapCall) apply(m mapInterface[string]) (any, bool) {
 				return nil, true
 			}
 		}
+		return nil, false
+	case opClear:
+		m.Clear()
 		return nil, false
 	default:
 		panic("invalid mapOp")


### PR DESCRIPTION
Add Clear() to Cache, Item, and Set, matching sync.Map.Clear (added in Go 1.23). Cache.Clear resets internal state under the lock; Item.Clear and Set.Clear delegate.

Fix NewItem and NewSet to delegate to New, which was previously skipped — this caused missing pd allocation and auto-clean goroutine setup.

Fix "the the" typo in CompareAndDelete docs, and add explicit parens to clarify operator precedence in ent.get.

Update test infrastructure (mapInterface, RWMutexMap, CacheMap, and quickcheck ops) for Clear. Update README mapping table.

---

MaxIdleAge resets an entry's expiry to now+age on each successful
Get/TryGet hit (no error), keeping entries alive while actively
accessed and expiring them after a period of inactivity. Range and
Delete do not extend. When used without MaxAge, MaxIdleAge serves
as the initial TTL.

Closes https://github.com/twmb/go-cache/issues/4.